### PR TITLE
remove left-over Application class declaration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     package="com.wiseassblog.kotlincalculator">
 
     <application
-        android:name=".KotlinCalculator"
-
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
The KotlinCalculator Application class defined the the Manifest ([here](https://github.com/BracketCove/KotlinMVPCalculator/blob/256c32d22d2e0bfa8b491ee82ab459ca1161e61d/app/src/main/AndroidManifest.xml#L6)) was removed in 7b910e2a93d94aa9b1a3cb4f80c50b0613d2d8d6.
Removed said declaration form the Manifest to avoid the application throwing `ClassNotFoundException`-s on launch.